### PR TITLE
Update DUB to v1.3.0 and DMD to v2.074.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.2.2
+version: 1.3.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,7 +15,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.2.2
+    source-tag: v1.3.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -32,7 +32,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.073.2
+    source-tag: &dmd-version v2.074.0
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This patch brings both the packaged DUB and the DMD used to build it up to their latest stable releases.