### PR TITLE
Update DUB to v1.5.0 and DMD to v2.076.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.4.0
+version: 1.5.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,7 +15,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.4.0
+    source-tag: v1.5.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -32,7 +32,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.075.0
+    source-tag: &dmd-version v2.076.0
     source-type: git
     plugin: make
     makefile: posix.mak
@@ -67,7 +67,7 @@ parts:
     plugin: make
     makefile: posix.mak
     make-parameters:
-    - DMD=../../dmd/build/src/dmd
+    - DMD_DIR=../../dmd/build
     organize:
       src/druntime/import: import/druntime
     stage:
@@ -86,7 +86,7 @@ parts:
     plugin: make
     makefile: posix.mak
     make-parameters:
-    - DMD=../../dmd/build/src/dmd
+    - DMD_DIR=../../dmd/build
     - DRUNTIME_PATH=../../druntime/build
     - VERSION=../../dmd/build/VERSION
     organize:


### PR DESCRIPTION
This patch brings the packaged DUB and the DMD used to build it up to date with their latest stable releases.

The v2.076.0 release expects druntime and phobos' make commands to be provided with a `DMD_DIR` variable instead of just a path to the `dmd` command, so `make-parameters` have been tweaked accordingly.

Fixes https://github.com/dlang-snaps/dub.snap/issues/4.