### PR TITLE
Update DUB to v1.6.0 and DMD to v2.077.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.5.0
+version: 1.6.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,7 +15,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.5.0
+    source-tag: v1.6.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -32,7 +32,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.076.0
+    source-tag: &dmd-version v2.077.1
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This is no longer the latest stable release, but ensures that this version of DUB will be available in the package history.