### PR TITLE
Update DUB to v1.9.0 and DMD to v2.080.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.8.1
+version: 1.9.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,7 +15,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.8.1
+    source-tag: v1.9.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -32,7 +32,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.079.1
+    source-tag: &dmd-version v2.080.0
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This patch brings the packaged DUB and the DMD used to build it up to date with their latest stable releases.

https://github.com/dlang/dub/releases/tag/v1.9.0