### PR TITLE
Update DUB to v1.10.0 and DMD to v2.081.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.9.0
+version: 1.10.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,7 +15,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.9.0
+    source-tag: v1.10.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -32,13 +32,13 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.080.0
+    source-tag: &dmd-version v2.081.1
     source-type: git
     plugin: make
     makefile: posix.mak
     make-parameters:
     - AUTO_BOOTSTRAP=1
-    - RELEASE=1
+    - ENABLE_RELEASE=1
     organize:
       linux/bin32: bin
       linux/bin64: bin


### PR DESCRIPTION
This patch brings the packaged DUB and the DMD used to build it up to date with their latest stable releases.

https://github.com/dlang/dub/releases/tag/v1.10.0