### PR TITLE
Update DUB to v1.13.0 and DMD to v2.084.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.10.0
+version: 1.13.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,7 +15,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.10.0
+    source-tag: v1.13.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -32,7 +32,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.081.1
+    source-tag: &dmd-version v2.084.1
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This patch brings the packaged DUB and the DMD used to build it up to date with their latest stable releases.

https://github.com/dlang/dub/releases/tag/v1.13.0

Note that this skips releases 1.11.x and 1.12.x.  The DUB snap package does not maintain minor version channels so there seems no point in doing anything other than upgrading to the latest stable release.