### PR TITLE
Bundle libcurl with the snap package

### DIFF
--- a/snap/license.txt
+++ b/snap/license.txt
@@ -5,6 +5,10 @@ DUB is released under the MIT License.  It statically links in druntime
 and phobos (the D standard library), which are both released under the
 Boost Software License (Version 1.0).
 
+This package also bundles `libcurl3-gnutls` and its dependencies.  Copyright
+and licensing information for these libraries can be found in the `copyright`
+files in the `usr/share/doc/*` directories inside the package.
+
 
 Full license texts
 ==================

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,8 @@ grade: stable
 apps:
   dub:
     command: bin/dub
+    environment:
+      LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 
 parts:
   dub:
@@ -29,6 +31,11 @@ parts:
     - dmd-config
     - druntime
     - phobos
+
+  curl:
+    plugin: nil
+    stage-packages:
+    - libcurl3-gnutls
 
   dmd:
     source: https://github.com/dlang/dmd.git


### PR DESCRIPTION
DUB uses `std.net.curl` to download package data, which in turn relies on being able to dynamically load libcurl at runtime via `dlopen`.  If libcurl is not available in the snap, but only on the host system, then DUB may not be able to locate it: this happens e.g. on Ubuntu 18.04 and quite possibly on other distros too.

This patch adds a separate `curl` part that includes `libcurl3-gnutls` via `stage-packages`.  This is simpler than adding it to the `dub` part as the `dump` plugin will not automatically stage packages specified in this way.

Besides the libraries themselves, we need to add extra `LD_LIBRARY_PATH` settings to the app environment to enable dub to find them.

Adapted from an earlier PR by @philburr: https://github.com/dlang-snaps/dub.snap/pull/13