### PR TITLE
Update DUB to 1.18.0 and DMD to 2.089.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.17.0
+version: 1.18.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -17,7 +17,7 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.17.0
+    source-tag: v1.18.0
     source-type: git
     plugin: dump
     prepare: DMD=../../../stage/bin/dmd ./build.sh
@@ -39,7 +39,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.088.1
+    source-tag: &dmd-version v2.089.0
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
This brings the packaged DUB and the DMD used to build it up to date with their latest stable releases:
https://github.com/dlang/dub/releases/tag/v1.18.0
https://github.com/dlang/dmd/releases/tag/v2.089.0