### PR TITLE
Add base and license specifiers to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,8 +5,11 @@ description: |
     DUB is a build tool for projects written in the D programming
     language, with support for automatically retrieving dependencies
     and integrating them into the build process.
+
+base: core
 confinement: classic
 grade: stable
+license: MIT AND BSL-1.0
 
 apps:
   dub:
@@ -20,7 +23,9 @@ parts:
     source-tag: v1.19.0
     source-type: git
     plugin: dump
-    prepare: DMD=../../../stage/bin/dmd ./build.sh
+    override-build: |
+        DMD=../../../stage/bin/dmd ./build.sh
+        snapcraftctl build
     stage:
     - bin/dub
     build-packages:


### PR DESCRIPTION
See https://snapcraft.io/docs/base-snaps for more details on base snaps.  The `core` base is chosen to ensure compatibility with Ubuntu 16.04.

The license spec is chosen to reflect the license of DUB itself and the druntime/phobos code required to build it.  System libraries are taken as given, as their license details are provided in `usr/share/doc`.

This change has a few notable impacts:

  * we need to replace the old `prepare:` scriptlet with the new `override-build` standard, and invoke `snapcraftctl build` to ensure that the install stage completes successfully

  * we can no longer build with snapcraft versions earlier than 3 or use the `snapcraft cleanbuild` command

  * by default snapcraft will now attempt to build using `multipass` (`snapcraft --use-lxd` will reproduce the old `cleanbuild`-style behaviour, while `snapcraft --destructive-mode` will build in the local environment)