### PR TITLE
Update to latest stable DUB/DMD releases and snap base

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
     language, with support for automatically retrieving dependencies
     and integrating them into the build process.
 
-base: core
+base: core18
 confinement: classic
 grade: stable
 license: MIT AND BSL-1.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.19.0
+version: 1.27.0
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -20,11 +20,11 @@ apps:
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.19.0
+    source-tag: v1.27.0
     source-type: git
     plugin: dump
     override-build: |
-        DMD=../../../stage/bin/dmd ./build.sh
+        ../../../stage/bin/dmd -run ./build.d
         snapcraftctl build
     stage:
     - bin/dub
@@ -50,7 +50,7 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.090.1
+    source-tag: &dmd-version v2.098.1
     source-type: git
     plugin: make
     makefile: posix.mak


### PR DESCRIPTION
These patches update the base snap to `core18` (long overdue as `core` is well out of its support period) and DUB and DMD respectively to upstream versions 1.27.0 and 2.098.1:
https://github.com/dlang/dub/releases/tag/v1.27.0
https://github.com/dlang/dmd/releases/tag/v2.098.1