### PR TITLE
Update DUB to 1.32.1 and DMD to 2.103.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: dub
-version: 1.27.0
+version: 1.32.1
 summary: Package and build manager for D applications and libraries
 description: |
     DUB is a build tool for projects written in the D programming
@@ -15,12 +15,12 @@ apps:
   dub:
     command: bin/dub
     environment:
-      LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib:$SNAP/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
+      LD_LIBRARY_PATH: $SNAP/release:$SNAP/lib/x86_64-linux-gnu:$SNAP/usr/lib/x86_64-linux-gnu
 
 parts:
   dub:
     source: https://github.com/dlang/dub.git
-    source-tag: v1.27.0
+    source-tag: v1.32.1
     source-type: git
     plugin: dump
     override-build: |
@@ -34,7 +34,6 @@ parts:
     after:
     - dmd
     - dmd-config
-    - druntime
     - phobos
 
   dub-license:
@@ -50,16 +49,20 @@ parts:
 
   dmd:
     source: https://github.com/dlang/dmd.git
-    source-tag: &dmd-version v2.098.1
+    source-tag: &dmd-version v2.103.1
     source-type: git
     plugin: make
     makefile: posix.mak
     make-parameters:
     - AUTO_BOOTSTRAP=1
     - ENABLE_RELEASE=1
+    override-build: |
+      snapcraftctl build
+      make -C druntime -f posix.mak install
     organize:
       linux/bin32: bin
       linux/bin64: bin
+      src/druntime/import: import/druntime
     stage:
     - -bin/dmd.conf
     - -linux
@@ -78,25 +81,6 @@ parts:
     prime:
     - -*
 
-  druntime:
-    source: https://github.com/dlang/druntime.git
-    source-tag: *dmd-version
-    source-type: git
-    plugin: make
-    makefile: posix.mak
-    make-parameters:
-    - DMD_DIR=../../dmd/build
-    organize:
-      src/druntime/import: import/druntime
-    stage:
-    - -src
-    prime:
-    - -*
-    build-packages:
-    - gcc
-    after:
-    - dmd
-
   phobos:
     source: https://github.com/dlang/phobos.git
     source-tag: *dmd-version
@@ -104,8 +88,9 @@ parts:
     plugin: make
     makefile: posix.mak
     make-parameters:
+    - CUSTOM_DRUNTIME=1
     - DMD_DIR=../../dmd/build
-    - DRUNTIME_PATH=../../druntime/build
+    - DRUNTIME_PATH=../../dmd/build/druntime
     - VERSION=../../dmd/build/VERSION
     organize:
       linux/lib32: lib32
@@ -120,4 +105,3 @@ parts:
     - gcc
     after:
     - dmd
-    - druntime


### PR DESCRIPTION
This brings the packaged DUB and the DMD used to build it up to date with their latest stable releases:
https://github.com/dlang/dub/releases/tag/v1.32.1
https://github.com/dlang/dmd/releases/tag/v2.103.1

Some changes to the DMD/druntime/phobos bootstrap process are needed, as their build setup has changed a little since the last package update:

  * `druntime` has been incorporated into the `dmd` repo: this allows us to cut the `druntime` part, but requires an `override-build` to make sure that druntime source files are included, and we need to add the old druntime `organize` settings to the `dmd` part

  * this requires a change to the `DRUNTIME_PATH` value used to build phobos; we must also add `CUSTOM_DRUNTIME=1`, or else the phobos build system will try to build druntime from scratch

The package's `environment` settings have also been updated, in response to a CVE affecting `snapcraft`:
https://ubuntu.com/security/CVE-2020-27348
https://forum.snapcraft.io/t/ann-snapcraft-4-4-4-library-injection-vulnerability-on-built-snaps/21465 https://forum.snapcraft.io/t/how-to-execute-a-binary-file-inside-a-snap/34342/12